### PR TITLE
Insert paramter variable in quotation mark

### DIFF
--- a/skrf/vi/vna/keysight/pna.py
+++ b/skrf/vi/vna/keysight/pna.py
@@ -283,7 +283,7 @@ class PNA(VNA):
             self.write(f"SENS{self.cnum}:AVER:CLE")
 
         def create_measurement(self, name: str, parameter: str) -> None:
-            self.write(f"CALC{self.cnum}:PAR:EXT '{name}',{parameter}")
+            self.write(f"CALC{self.cnum}:PAR:EXT '{name}','{parameter}'")
             # Not all instruments support DISP:WIND:TRAC:NEXT
             traces = self.query("DISP:WIND:CAT?").replace('"', "")
             traces = [int(tr) for tr in traces.split(",")] if traces != "EMPTY" else [0]


### PR DESCRIPTION
Added quotation mark to the formatting string.
This also makes it possible to create reciver measurements. 

e.g. a1,1